### PR TITLE
Upgrade java so maven can compile it, and cleanup the code

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,8 +48,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>2.3.2</version>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                 </configuration>
             </plugin>
             <plugin>

--- a/src/main/java/com/d2fn/guano/DumpJob.java
+++ b/src/main/java/com/d2fn/guano/DumpJob.java
@@ -1,11 +1,13 @@
 package com.d2fn.guano;
 
-import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.WatchedEvent;
 import org.apache.zookeeper.Watcher;
 import org.apache.zookeeper.ZooKeeper;
 import org.apache.zookeeper.data.Stat;
 
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
 import java.util.List;
 
 /**
@@ -94,7 +96,5 @@ public class DumpJob implements Job, Watcher {
     }
 
     @Override
-    public void process(WatchedEvent watchedEvent) {
-        ;;
-    }
+    public void process(WatchedEvent watchedEvent) {}
 }

--- a/src/main/java/com/d2fn/guano/FSVisitor.java
+++ b/src/main/java/com/d2fn/guano/FSVisitor.java
@@ -7,5 +7,5 @@ import java.io.File;
  * @author Dietrich Featherston
  */
 public interface FSVisitor {
-    public void visit(File f, byte[] data, String znode);
+    void visit(File f, byte[] data, String znode);
 }

--- a/src/main/java/com/d2fn/guano/Guano.java
+++ b/src/main/java/com/d2fn/guano/Guano.java
@@ -14,7 +14,6 @@ public class Guano implements Job {
     private Job job;
 
     public Guano(Options options, CommandLine cmd) {
-//        buildJob(cmd)
         this.options = options;
         this.cmd = cmd;
         buildJob();
@@ -34,7 +33,7 @@ public class Guano implements Job {
 
         String server = cmd.getOptionValue("s");
 
-        // dump?
+        // dump
         if(cmd.hasOption("d") && cmd.hasOption("o")) {
             String znode = cmd.getOptionValue("d");
             String outputDir = cmd.getOptionValue("o");
@@ -63,6 +62,8 @@ public class Guano implements Job {
         try {
             cmd = parser.parse(options, args);
         } catch (ParseException e) {
+            System.out.println("There was an exception in parsing\n" + e.toString());
+            System.out.println("Valid options:");
             usage(options);
         }
 

--- a/src/main/java/com/d2fn/guano/Job.java
+++ b/src/main/java/com/d2fn/guano/Job.java
@@ -5,5 +5,5 @@ package com.d2fn.guano;
  * @author Dietrich Featherston
  */
 public interface Job {
-    public void go();
+    void go();
 }

--- a/src/main/java/com/d2fn/guano/RestoreJob.java
+++ b/src/main/java/com/d2fn/guano/RestoreJob.java
@@ -1,10 +1,8 @@
 package com.d2fn.guano;
 
 import org.apache.zookeeper.*;
-import org.apache.zookeeper.data.ACL;
 
 import java.io.File;
-import java.util.ArrayList;
 import java.util.Arrays;
 
 /**
@@ -55,16 +53,12 @@ public class RestoreJob implements Job, Watcher, FSVisitor {
      */
     @Override
     public void visit(File f, byte[] data, String znode) {
-//        System.out.println(f.getPath());
-//        System.out.println(" -> " + znode);
         createOrSetZnode(data, znode);
     }
 
     private void createOrSetZnode(byte[] data, String znode) {
         try {
             String s = zk.create(znode, data, ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
-        } catch (KeeperException.NoNodeException e) {
-            e.printStackTrace(System.err);
         } catch (KeeperException.NodeExistsException e) {
             try {
                 byte[] zdata = zk.getData(znode, false, null);
@@ -74,15 +68,11 @@ public class RestoreJob implements Job, Watcher, FSVisitor {
             } catch (Exception e2) {
                 e2.printStackTrace(System.err);
             }
-        } catch (KeeperException e) {
-            e.printStackTrace(System.err);
-        } catch (InterruptedException e) {
+        } catch (KeeperException | InterruptedException e) {
             e.printStackTrace(System.err);
         }
     }
 
     @Override
-    public void process(WatchedEvent watchedEvent) {
-        ;;
-    }
+    public void process(WatchedEvent watchedEvent) {}
 }


### PR DESCRIPTION
The maven compiler plugin didn't allow for such old versions of Java so I upgraded it. In addition I:

1. Removed unused imports and added imports for things that aren't auto-included in Java8.
2. Cleaned up a few comments.
3. Removed `public` from methods in interfaces because it is redundant and new versions of Java encourage against adding that modifier.
4. Fixed up some of the `catch` blocks, one was missing some context, and others have redundant logic.

Working on: [FOUND-31](https://strava.atlassian.net/browse/FOUND-31)