### PR TITLE
Hye/fix recursive znodes bug

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+FROM openjdk:8 as guano-package-builder
+
+WORKDIR /usr/app/guano
+
+COPY . .
+
+RUN apt-get update; \
+    apt-get install --yes maven; \
+    mvn clean package
+
+
+FROM java:8-jdk-alpine
+
+RUN mkdir /usr/app
+
+COPY --from=guano-package-builder /usr/app/guano/target/guano-0.2.jar /usr/app
+COPY ./docker-entrypoint.sh /usr/app
+
+WORKDIR /usr/app
+
+ENTRYPOINT [ "./docker-entrypoint.sh"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec java -jar ./guano-0.2.jar "$@"

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.d2fn</groupId>
     <artifactId>guano</artifactId>
-    <version>0.1a</version>
+    <version>0.2</version>
 
     <name>guano</name>
     <packaging>jar</packaging>

--- a/src/main/java/com/d2fn/guano/DumpJob.java
+++ b/src/main/java/com/d2fn/guano/DumpJob.java
@@ -84,16 +84,20 @@ public class DumpJob implements Job, Watcher {
     private void writeZnode(ZooKeeper zk, String outFile, String znode) throws Exception {
         Stat stat = new Stat();
         byte[] data = zk.getData(znode, false, stat);
+
+        FileOutputStream out = new FileOutputStream(outFile);
+
         if(data != null && data.length > 0 && stat.getEphemeralOwner() == 0) {
-            String str = new String(data);
+            String str = new String(data); //Also what about data that can't be string? are there such cases?
             if(!str.equals("null")) {
-                FileOutputStream out = new FileOutputStream(outFile);
                 out.write(data);
-                out.flush();
-                out.close();
             }
         }
+
+        out.flush();
+        out.close();
     }
+
 
     @Override
     public void process(WatchedEvent watchedEvent) {}


### PR DESCRIPTION
Output looks like what I expect now.

```dev/strava/guano  hye/fix-recursive-znodes-bug ✗                                                                                                0m ◒  
▶ ls -lR /tmp/guano-backups   
total 0
drwxr-xr-x  6 hanluye  wheel  192 Apr 13 13:26 animals

/tmp/guano-backups/animals:
total 16
-rw-r--r--  1 hanluye  wheel    0 Apr 13 13:26 _znode
-rw-r--r--  1 hanluye  wheel    5 Apr 13 13:26 bird
drwxr-xr-x  5 hanluye  wheel  160 Apr 13 13:26 mammal
-rw-r--r--  1 hanluye  wheel    9 Apr 13 13:26 reptile

/tmp/guano-backups/animals/mammal:
total 8
-rw-r--r--  1 hanluye  wheel   0 Apr 13 13:26 _znode
-rw-r--r--  1 hanluye  wheel  10 Apr 13 13:26 bear
-rw-r--r--  1 hanluye  wheel   0 Apr 13 13:26 hippo```

I also included the Dockerfile and entrypoint script from the config directory. I think it'd be nice to have a quick and easy build process that spits out the jar -- it took me far too long to wire everything up. I don't really care where it goes, but that the jar can be created without too much thinking.